### PR TITLE
Fixed a typo and made the German localization a bit more consistent

### DIFF
--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -130,7 +130,7 @@
   <string name="ui_email_address_style_label">E-Mail Adress-Stil</string>
   <string name="ui_email_address_style_desc">Format der E-Mail-Adressen</string>
 
-  <string name="ui_enable_auto_sync_label">Atomatische Sicherung</string>
+  <string name="ui_enable_auto_sync_label">Automatische Sicherung</string>
   <string name="ui_enable_auto_sync_desc">Ob neue SMS automatisch gesichert werden sollen.</string>
   <string name="ui_enable_auto_sync_summary">Automatische Sicherung von %1$s.</string>
 
@@ -275,7 +275,7 @@
   <string name="ui_restore_settings_label">Wiederherstellungseinstellungen</string>
   <!-- <string name="ui_restore_settings_desc">Restore settings</string> -->
 
-  <string name="ui_backup_sms_label">SMS Sicherung</string>
+  <string name="ui_backup_sms_label">SMS sichern</string>
   <string name="ui_backup_sms_desc">SMS Sicherung aktivieren</string>
 
   <string name="ui_restore_sms_label">SMS Wiederherstellung</string>


### PR DESCRIPTION
"Atomatische Sicherung" should be "Automatische Sicherung". 

It should either be "SMS Sicherung" and "MMS Sicherung" or "SMS sichern" and "MMS sichern" and not a mix of both. (I prefer the latter)
