### PR TITLE
[NOT A PULL REQUEST] Request SMS Backup+ to be the default SMS package before restoring

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -84,6 +84,51 @@
           </intent-filter>
         </receiver>
 
+        <!-- BroadcastReceiver that listens for incoming SMS messages -->
+        <receiver android:name=".SmsReceiver"
+                android:permission="android.permission.BROADCAST_SMS">
+            <intent-filter>
+                <action android:name="android.provider.Telephony.SMS_DELIVER" />
+            </intent-filter>
+        </receiver>
+
+        <!-- BroadcastReceiver that listens for incoming MMS messages -->
+        <receiver android:name=".MmsReceiver"
+            android:permission="android.permission.BROADCAST_WAP_PUSH">
+            <intent-filter>
+                <action android:name="android.provider.Telephony.WAP_PUSH_DELIVER" />
+                <data android:mimeType="application/vnd.wap.mms-message" />
+            </intent-filter>
+        </receiver>
+
+        <!-- Activity that allows the user to send new SMS/MMS messages -->
+        <activity android:name=".ComposeSmsActivity" >
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />                
+                <action android:name="android.intent.action.SENDTO" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="sms" />
+                <data android:scheme="smsto" />
+                <data android:scheme="mms" />
+                <data android:scheme="mmsto" />
+            </intent-filter>
+        </activity>
+
+        <!-- Service that delivers messages from the phone "quick response" -->
+        <service android:name=".HeadlessSmsSendService"
+                 android:permission="android.permission.SEND_RESPOND_VIA_MESSAGE"
+                 android:exported="true" >
+            <intent-filter>
+                <action android:name="android.intent.action.RESPOND_VIA_MESSAGE" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="sms" />
+                <data android:scheme="smsto" />
+                <data android:scheme="mms" />
+                <data android:scheme="mmsto" />
+            </intent-filter>
+        </service>
+
         <meta-data
             android:name="com.google.android.backup.api_key"
             android:value="AEdPqrEAAAAI15zt2oJAvxMu4s5SaHisDyYsduKd2jq_-XnAug" />

--- a/build.gradle
+++ b/build.gradle
@@ -28,8 +28,8 @@ dependencies {
 }
 
 android {
-  buildToolsVersion '17'
-  compileSdkVersion 17
+  buildToolsVersion '19'
+  compileSdkVersion 19
 
   sourceSets {
     main {

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <platform.version>4.0.1.2</platform.version>
+        <platform.version>4.4</platform.version>
     </properties>
 
     <dependencies>
@@ -96,7 +96,7 @@
                   <assetsDirectory>${project.basedir}/assets</assetsDirectory>
                   <resourceDirectory>${project.basedir}/res</resourceDirectory>
                   <sdk>
-                     <platform>14</platform>
+                     <platform>19</platform>
                   </sdk>
                   <undeployBeforeDeploy>true</undeployBeforeDeploy>
                   <lint>

--- a/src/com/zegoggles/smssync/Consts.java
+++ b/src/com/zegoggles/smssync/Consts.java
@@ -31,6 +31,12 @@ public final class Consts {
     public static final String KEY_SKIP_MESSAGES = "com.zegoggles.smssync.SkipMessages";
 
     /**
+     * Key in the intent extras for storing the previously set default sms provider,
+     * allowing it to be restored after the restore finishes.
+     */
+    public static final String KEY_DEFAULT_SMS_PROVIDER = "com.zegoggles.smssync.DefaultSmsProvider";
+
+    /**
      * OAuth callback
      */
     public static final String CALLBACK_URL = "smssync://gmail";


### PR DESCRIPTION
Request SMS Backup+ to be set as the default SMS package before restoring.

**THIS PATCH HAS A NUMBER OF TODOS AND SHOULD NOT LAND AS IS.**

Starting with Android KitKat, only the default SMS package is allowed to
write to the SMS provider. Because SMS Backup+ did not register for the
ComposeSmsActivity activity or the receivers at all, it could not be set
as such, rendering the restore functionality useless in KitKat.

This patch somewhat hacks the necessary functionality in the application to
make it possible to import SMS messages again. It adds the necessary
receivers and activity to the AndroidManifest.xml file (but does not become
the default SMS app by default) and adds some logic to the restore flow:
- When starting the restore, request to become the default SMS package
    if the user is running KitKat or higher and it's not already.
- If the default SMS activity has changed, add this as an intent with
    which we're launching the service.
- In the SmsRestoreService, abort restoring if we're not able to write
    to the SMS provider. A better message should be added here.
- After the restore finished, check if the previous-sms-provider intent
    extra has been set. If so, ask the user to restore to that activity.

It's important to reset the default SMS provider to something that's not
SMS Backup+, because otherwise incoming messages will disappear in a black
hole. There's a lot of user interaction involved here, but I'm not sure if
there's a good way around that.

This patch is not ready to land, but I hope it gives you a good idea about
what's needed to fix restore for Android KitKat and higher. It allowed me
to import my SMS messages just fine :-). Thanks for the great app!
