### PR TITLE
too many duplicate for call logs when restoring

### DIFF
--- a/src/main/java/com/zegoggles/smssync/service/RestoreTask.java
+++ b/src/main/java/com/zegoggles/smssync/service/RestoreTask.java
@@ -277,8 +277,9 @@ class RestoreTask extends AsyncTask<RestoreConfig, RestoreState, RestoreState> {
     private boolean callLogExists(ContentValues values) {
         Cursor c = resolver.query(Consts.CALLLOG_PROVIDER,
             new String[] { "_id" },
-            "number = ? AND duration = ? AND type = ?",
+            "date = ? AND number = ? AND duration = ? AND type = ?",
             new String[]{
+                values.getAsString(CallLog.Calls.DATE),
                 values.getAsString(CallLog.Calls.NUMBER),
                 values.getAsString(CallLog.Calls.DURATION),
                 values.getAsString(CallLog.Calls.TYPE)


### PR DESCRIPTION
```
 add more criteria , to lookup for duplicate for call logs .
 without this patch , we restore only one call-log by number .
```
