### PR TITLE
Improve restore experience

### DIFF
--- a/res/values-ru/strings.xml
+++ b/res/values-ru/strings.xml
@@ -90,7 +90,7 @@
    <string name="ui_max_items_per_sync_label">Количество SMS для сохранения</string>
   <string name="ui_max_items_per_sync_desc">Максимальное количество SMS для сохранения.</string>
   <string name="ui_max_items_per_restore_label">Количество SMS для восстановления</string>
-  <string name="ui_max_items_per_restore_desc">Максимальное количество SMS для восстановления.</string>
+  <string name="ui_max_items_per_restore_desc">Количество новейших SMS для восстановления.</string>
 
 
   <string name="ui_restore_starred_only_label">Отмеченные SMS</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -90,7 +90,7 @@
   <string name="ui_max_items_per_sync_label">Items per backup</string>
   <string name="ui_max_items_per_sync_desc">Maximum number of items per backup.</string>
   <string name="ui_max_items_per_restore_label">Items per restore</string>
-  <string name="ui_max_items_per_restore_desc">Maximum number of restored messages.</string>
+  <string name="ui_max_items_per_restore_desc">Number of latest messages to restore.</string>
 
   <string name="ui_restore_starred_only_label">Starred items</string>
   <string name="ui_restore_starred_only_desc">Only restore starred items.</string>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -208,7 +208,7 @@
                     android:summary="@string/ui_max_items_per_restore_desc"
                     android:entries="@array/max_items_per_restore_entries"
                     android:entryValues="@array/max_items_per_restore_values"
-                    android:defaultValue="-1"
+                    android:defaultValue="500"
                     android:persistent="true"/>
 
             <CheckBoxPreference

--- a/src/main/java/com/zegoggles/smssync/service/RestoreTask.java
+++ b/src/main/java/com/zegoggles/smssync/service/RestoreTask.java
@@ -121,15 +121,16 @@ class RestoreTask extends AsyncTask<RestoreConfig, RestoreState, RestoreState> {
                         service.clearCache();
                     }
                 }
-                if (!isCancelled()) {
-                    publishProgress(UPDATING_THREADS);
-                    updateAllThreads();
-                }
             } else {
                 Log.d(TAG, "nothing to restore");
             }
 
             final int restoredCount = smsIds.size() + callLogIds.size();
+            if (restoredCount > 0) {
+                publishProgress(UPDATING_THREADS);
+                updateAllThreads();
+            }
+
             return new RestoreState(isCancelled() ? CANCELED_RESTORE : FINISHED_RESTORE,
                     currentRestoredItem,
                     itemsToRestoreCount,

--- a/src/main/java/com/zegoggles/smssync/service/RestoreTask.java
+++ b/src/main/java/com/zegoggles/smssync/service/RestoreTask.java
@@ -121,9 +121,7 @@ class RestoreTask extends AsyncTask<RestoreConfig, RestoreState, RestoreState> {
                         service.clearCache();
                     }
                 }
-                if (smsIds.size() > 0) {
-                    updateAllThreads();
-                }
+                updateAllThreadsIfAnySmsRestored();
             } else {
                 Log.d(TAG, "nothing to restore");
             }
@@ -140,9 +138,7 @@ class RestoreTask extends AsyncTask<RestoreConfig, RestoreState, RestoreState> {
             return transition(ERROR, e);
         } catch (MessagingException e) {
             Log.e(TAG, "error", e);
-            if (smsIds.size() > 0) {
-                updateAllThreads();
-            }
+            updateAllThreadsIfAnySmsRestored();
             return transition(ERROR, e);
         } catch (IllegalStateException e) {
             // usually memory problems (Couldn't init cursor window)
@@ -322,6 +318,12 @@ class RestoreTask extends AsyncTask<RestoreConfig, RestoreState, RestoreState> {
             c.close();
         }
         return exists;
+    }
+
+    private void updateAllThreadsIfAnySmsRestored() {
+        if (smsIds.size() > 0) {
+            updateAllThreads();
+        }
     }
 
     private void updateAllThreads() {

--- a/src/main/java/com/zegoggles/smssync/service/RestoreTask.java
+++ b/src/main/java/com/zegoggles/smssync/service/RestoreTask.java
@@ -121,16 +121,14 @@ class RestoreTask extends AsyncTask<RestoreConfig, RestoreState, RestoreState> {
                         service.clearCache();
                     }
                 }
+                if (smsIds.size() > 0) {
+                    updateAllThreads();
+                }
             } else {
                 Log.d(TAG, "nothing to restore");
             }
 
             final int restoredCount = smsIds.size() + callLogIds.size();
-            if (restoredCount > 0) {
-                publishProgress(UPDATING_THREADS);
-                updateAllThreads();
-            }
-
             return new RestoreState(isCancelled() ? CANCELED_RESTORE : FINISHED_RESTORE,
                     currentRestoredItem,
                     itemsToRestoreCount,
@@ -142,6 +140,9 @@ class RestoreTask extends AsyncTask<RestoreConfig, RestoreState, RestoreState> {
             return transition(ERROR, e);
         } catch (MessagingException e) {
             Log.e(TAG, "error", e);
+            if (smsIds.size() > 0) {
+                updateAllThreads();
+            }
             return transition(ERROR, e);
         } catch (IllegalStateException e) {
             // usually memory problems (Couldn't init cursor window)
@@ -327,6 +328,7 @@ class RestoreTask extends AsyncTask<RestoreConfig, RestoreState, RestoreState> {
         // thread dates + states might be wrong, we need to force a full update
         // unfortunately there's no direct way to do that in the SDK, but passing a
         // negative conversation id to delete should to the trick
+        publishProgress(UPDATING_THREADS);
         Log.d(TAG, "updating threads");
         resolver.delete(Uri.parse("content://sms/conversations/-1"), null, null);
         Log.d(TAG, "finished");


### PR DESCRIPTION
I have upgraded to Android M yesterday and had quite a few problems with restoring of my 15000+ messages (not related to Android version).

I think the restore experience can be improved by default so that more people will get it working as expected.

Reading the code I realized that messages are restored in reverse order: latest first. I assumed that the order is oldest first and that's why kept the number of restored messages to 'All' in settings. It seems that changing a couple of strings can fix that wrong assumption.

Restoring a lot of messages by default fails after at least 30 minutes with e.g. timeout of IMAP server. Most people probably will be ok with that if the latest a few thousand messages would be restored, but due to failure the restored messages are not visible (threads not updated). I propose to change the default restored count to 500 so that most people will not wait for 30 min but get at least 500 latest messages back pretty quickly. In addition, RestoreTask will now attempt to still call updateAllThreads() even in case of IMAP failure so that the restored messages already in sms.db will become visible.
