### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/src/main/java/com/zegoggles/smssync/Consts.java
+++ b/src/main/java/com/zegoggles/smssync/Consts.java
@@ -63,5 +63,9 @@ public final class Consts {
                 SKU_DONATION_2,
                 SKU_DONATION_3,
         };
+
+        private Billing() {}
     }
+
+    private Consts() {}
 }

--- a/src/main/java/com/zegoggles/smssync/calendar/CalendarAccessor.java
+++ b/src/main/java/com/zegoggles/smssync/calendar/CalendarAccessor.java
@@ -39,6 +39,8 @@ public interface CalendarAccessor {
     public static class Get {
         private static CalendarAccessor sCalendarAccessor;
 
+        private Get() {}
+
         public static CalendarAccessor instance(ContentResolver resolver) {
             final  int sdkVersion = Build.VERSION.SDK_INT;
             if (sCalendarAccessor == null) {

--- a/src/main/java/com/zegoggles/smssync/contacts/ContactAccessor.java
+++ b/src/main/java/com/zegoggles/smssync/contacts/ContactAccessor.java
@@ -54,6 +54,9 @@ public interface ContactAccessor {
 
     public static class Get {
         private static ContactAccessor sContactAccessor;
+
+        private Get() {}
+
         public static ContactAccessor instance() {
             final int sdkVersion = Build.VERSION.SDK_INT;
             if (sContactAccessor == null) {

--- a/src/main/java/com/zegoggles/smssync/mail/Attachment.java
+++ b/src/main/java/com/zegoggles/smssync/mail/Attachment.java
@@ -29,6 +29,8 @@ class Attachment {
     private static final String RFC2231_SPECIALS = "*'%" + MIME_SPECIALS;
     private static final char[] HEX_DIGITS = "0123456789ABCDEF".toCharArray();
 
+    private Attachment() {}
+
     public static MimeBodyPart createTextPart(String text) throws MessagingException {
         return new MimeBodyPart(new TextBody(text));
     }

--- a/src/main/java/com/zegoggles/smssync/mail/DataType.java
+++ b/src/main/java/com/zegoggles/smssync/mail/DataType.java
@@ -135,6 +135,8 @@ public enum DataType {
         public static final String MAX_SYNCED_DATE_SMS = "max_synced_date";
         public static final String MAX_SYNCED_DATE_MMS = "max_synced_date_mms";
         public static final String MAX_SYNCED_DATE_CALLLOG = "max_synced_date_calllog";
+
+        private PreferenceKeys() {}
     }
 
     /**
@@ -152,5 +154,7 @@ public enum DataType {
         public static final boolean SMS_RESTORE_ENABLED      = true;
         public static final boolean MMS_RESTORE_ENABLED      = false;
         public static final boolean CALLLOG_RESTORE_ENABLED  = true;
+
+        private Defaults() {}
     }
 }

--- a/src/main/java/com/zegoggles/smssync/mail/Headers.java
+++ b/src/main/java/com/zegoggles/smssync/mail/Headers.java
@@ -23,6 +23,8 @@ public final class Headers {
     public static final String REFERENCES = "References";
     public static final String MESSAGE_ID = "Message-ID";
 
+    private Headers() {}
+
     public static String get(Message msg, String header) {
         try {
             String[] hdrs = msg.getHeader(header);

--- a/src/main/java/com/zegoggles/smssync/preferences/BackupManagerWrapper.java
+++ b/src/main/java/com/zegoggles/smssync/preferences/BackupManagerWrapper.java
@@ -11,6 +11,8 @@ import static com.zegoggles.smssync.App.TAG;
 public class BackupManagerWrapper {
     static Boolean available = null;
 
+    private BackupManagerWrapper() {}
+
     static boolean available() {
         if (available == null) {
             try {

--- a/src/main/java/com/zegoggles/smssync/preferences/Defaults.java
+++ b/src/main/java/com/zegoggles/smssync/preferences/Defaults.java
@@ -23,4 +23,6 @@ class Defaults {
     public static final int MAX_ITEMS_PER_SYNC = -1;
     public static final int MAX_ITEMS_PER_RESTORE = -1;
     public static final boolean MARK_AS_READ_ON_RESTORE = true;
+
+    private Defaults() {}
 }

--- a/src/main/java/com/zegoggles/smssync/preferences/ServerPreferences.java
+++ b/src/main/java/com/zegoggles/smssync/preferences/ServerPreferences.java
@@ -41,5 +41,7 @@ public class ServerPreferences {
          * Default value for {@link ServerPreferences#SERVER_PROTOCOL}.
          */
         public static final String SERVER_PROTOCOL = "+ssl+";
+
+        private Defaults() {}
     }
 }

--- a/src/main/java/com/zegoggles/smssync/utils/Sanitizer.java
+++ b/src/main/java/com/zegoggles/smssync/utils/Sanitizer.java
@@ -3,6 +3,9 @@ package com.zegoggles.smssync.utils;
 import org.apache.james.mime4j.codec.EncoderUtil;
 
 public final class Sanitizer {
+
+    private Sanitizer() {}
+
     public static String sanitize(String s) {
         return s != null ? s.replaceAll("\\p{Cntrl}", "") : null;
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
This pull request removes technical debt of 360 minutes.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava