### PR TITLE
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/src/main/java/com/zegoggles/smssync/mail/Attachment.java
+++ b/src/main/java/com/zegoggles/smssync/mail/Attachment.java
@@ -24,6 +24,11 @@ import java.io.UnsupportedEncodingException;
 import static com.zegoggles.smssync.App.TAG;
 
 class Attachment {
+    // RFC2231 encoding from geronimo-javamail
+    private static final String MIME_SPECIALS = "()<>@,;:\\\"/[]?=" + "\t ";
+    private static final String RFC2231_SPECIALS = "*'%" + MIME_SPECIALS;
+    private static final char[] HEX_DIGITS = "0123456789ABCDEF".toCharArray();
+
     public static MimeBodyPart createTextPart(String text) throws MessagingException {
         return new MimeBodyPart(new TextBody(text));
     }
@@ -113,11 +118,6 @@ class Attachment {
         public void setEncoding(String s) throws MessagingException {
         }
     }
-
-    // RFC2231 encoding from geronimo-javamail
-    private static final String MIME_SPECIALS = "()<>@,;:\\\"/[]?=" + "\t ";
-    private static final String RFC2231_SPECIALS = "*'%" + MIME_SPECIALS;
-    private static final char[] HEX_DIGITS = "0123456789ABCDEF".toCharArray();
 
     protected static String encodeRFC2231(String key, String value) {
         StringBuilder buf = new StringBuilder();

--- a/src/main/java/com/zegoggles/smssync/preferences/AuthPreferences.java
+++ b/src/main/java/com/zegoggles/smssync/preferences/AuthPreferences.java
@@ -20,20 +20,6 @@ import static com.zegoggles.smssync.App.TAG;
 import static com.zegoggles.smssync.preferences.ServerPreferences.Defaults.SERVER_PROTOCOL;
 
 public class AuthPreferences {
-    private final Context context;
-    private final SharedPreferences preferences;
-    private final ServerPreferences serverPreferences;
-
-    public AuthPreferences(Context context) {
-        this(context,  new ServerPreferences(context));
-    }
-
-    /* package */ AuthPreferences(Context context, ServerPreferences serverPreferences) {
-        this.context = context.getApplicationContext();
-        this.serverPreferences = serverPreferences;
-        this.preferences =  PreferenceManager.getDefaultSharedPreferences(this.context);
-    }
-
     /**
      * Preference key containing the Google account username.
      */
@@ -63,6 +49,20 @@ public class AuthPreferences {
      * </ol>
      */
     private static final String IMAP_URI = "imap%s://%s:%s:%s@%s";
+
+    private final Context context;
+    private final SharedPreferences preferences;
+    private final ServerPreferences serverPreferences;
+
+    public AuthPreferences(Context context) {
+        this(context,  new ServerPreferences(context));
+    }
+
+    /* package */ AuthPreferences(Context context, ServerPreferences serverPreferences) {
+        this.context = context.getApplicationContext();
+        this.serverPreferences = serverPreferences;
+        this.preferences =  PreferenceManager.getDefaultSharedPreferences(this.context);
+    }
 
     @Deprecated
     public XOAuthConsumer getOAuthConsumer() {

--- a/src/main/java/com/zegoggles/smssync/preferences/ServerPreferences.java
+++ b/src/main/java/com/zegoggles/smssync/preferences/ServerPreferences.java
@@ -7,10 +7,6 @@ import android.preference.PreferenceManager;
 public class ServerPreferences {
     private final SharedPreferences preferences;
 
-    public ServerPreferences(Context context) {
-        this.preferences = PreferenceManager.getDefaultSharedPreferences(context);
-    }
-
     /**
      * Preference key containing the server address
      */
@@ -20,6 +16,9 @@ public class ServerPreferences {
      */
     private static final String SERVER_PROTOCOL = "server_protocol";
 
+    public ServerPreferences(Context context) {
+        this.preferences = PreferenceManager.getDefaultSharedPreferences(context);
+    }
 
     String getServerAddress() {
         return preferences.getString(SERVER_ADDRESS, Defaults.SERVER_ADDRESS);

--- a/src/main/java/com/zegoggles/smssync/service/BackupType.java
+++ b/src/main/java/com/zegoggles/smssync/service/BackupType.java
@@ -10,13 +10,13 @@ public enum BackupType {
     UNKNOWN(R.string.source_unknown),
     MANUAL(R.string.source_manual);
 
+    public static final String EXTRA = "com.zegoggles.smssync.BackupTypeAsString";
+
     public final int resId;
 
     BackupType(int resId) {
         this.resId = resId;
     }
-
-    public static final String EXTRA = "com.zegoggles.smssync.BackupTypeAsString";
 
     public static BackupType fromIntent(Intent intent) {
         if (intent.hasExtra(EXTRA)) {


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
This pull request removes 85 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
George Kankava