### PR TITLE
squid:S1192 - String literals should not be duplicated

### DIFF
--- a/src/main/java/com/zegoggles/smssync/auth/OAuth2Client.java
+++ b/src/main/java/com/zegoggles/smssync/auth/OAuth2Client.java
@@ -104,6 +104,7 @@ public class OAuth2Client {
      */
     private static final String CODE = "code";
     private static final String REFRESH_TOKEN = "refresh_token";
+    private static final String ERROR = "error";
 
     private final String clientId;
 
@@ -212,13 +213,13 @@ public class OAuth2Client {
             }
 
         } catch (SAXException e) {
-            Log.e(TAG, "error", e);
+            Log.e(TAG, ERROR, e);
             return null;
         } catch (IOException e) {
-            Log.e(TAG, "error", e);
+            Log.e(TAG, ERROR, e);
             return null;
         } catch (ParserConfigurationException e) {
-            Log.e(TAG, "error", e);
+            Log.e(TAG, ERROR, e);
             return null;
         }
     }

--- a/src/main/java/com/zegoggles/smssync/auth/XOAuthConsumer.java
+++ b/src/main/java/com/zegoggles/smssync/auth/XOAuthConsumer.java
@@ -72,12 +72,13 @@ import static oauth.signpost.OAuth.percentEncode;
 public class XOAuthConsumer extends CommonsHttpOAuthConsumer {
     private static final String MAC_NAME = "HmacSHA1";
     private static final String ANONYMOUS = "anonymous";
+    private static final String ERROR = "error";
 
     // Scopes as defined in http://code.google.com/apis/accounts/docs/OAuth.html#prepScope
     private static final String GMAIL_SCOPE = "https://mail.google.com/";
     private static final String CONTACTS_SCOPE = "https://www.google.com/m8/feeds/";
-    private static final String DEFAULT_SCOPE  = GMAIL_SCOPE + " " + CONTACTS_SCOPE;
 
+    private static final String DEFAULT_SCOPE  = GMAIL_SCOPE + " " + CONTACTS_SCOPE;
     // endpoints
     private static final String CONTACTS_URL = "https://www.google.com/m8/feeds/contacts/default/thin?max-results=1";
     private static final String REQUEST_TOKEN_URL = "https://www.google.com/accounts/OAuthGetRequestToken" +
@@ -220,16 +221,16 @@ public class XOAuthConsumer extends CommonsHttpOAuthConsumer {
             HttpGet get = new HttpGet(sign(CONTACTS_URL));
             return extractEmail(httpClient.execute(get));
         } catch (OAuthException e) {
-            Log.e(TAG, "error", e);
+            Log.e(TAG, ERROR, e);
             return null;
         } catch (SAXException e) {
-            Log.e(TAG, "error", e);
+            Log.e(TAG, ERROR, e);
             return null;
         } catch (IOException e) {
-            Log.e(TAG, "error", e);
+            Log.e(TAG, ERROR, e);
             return null;
         } catch (ParserConfigurationException e) {
-            Log.e(TAG, "error", e);
+            Log.e(TAG, ERROR, e);
             return null;
         }
     }

--- a/src/main/java/com/zegoggles/smssync/mail/HeaderGenerator.java
+++ b/src/main/java/com/zegoggles/smssync/mail/HeaderGenerator.java
@@ -22,6 +22,7 @@ import static com.zegoggles.smssync.utils.Sanitizer.sanitize;
 class HeaderGenerator {
     private static final String REFERENCE_UID_TEMPLATE = "<%s.%s@sms-backup-plus.local>";
     private static final String MSG_ID_TEMPLATE        = "<%s@sms-backup-plus.local>";
+    private static final String UTF_8 = "UTF-8";
 
     private final String reference;
     private final String version;
@@ -103,11 +104,11 @@ class HeaderGenerator {
         try {
             final MessageDigest digest = MessageDigest.getInstance("MD5");
 
-            digest.update(Long.toString(sent.getTime()).getBytes("UTF-8"));
+            digest.update(Long.toString(sent.getTime()).getBytes(UTF_8));
             if (address != null) {
-                digest.update(address.getBytes("UTF-8"));
+                digest.update(address.getBytes(UTF_8));
             }
-            digest.update(Integer.toString(type).getBytes("UTF-8"));
+            digest.update(Integer.toString(type).getBytes(UTF_8));
 
             final StringBuilder sb = new StringBuilder();
             for (byte b : digest.digest()) {

--- a/src/main/java/com/zegoggles/smssync/mail/MessageGenerator.java
+++ b/src/main/java/com/zegoggles/smssync/mail/MessageGenerator.java
@@ -31,6 +31,7 @@ import static com.zegoggles.smssync.App.TAG;
 import static com.zegoggles.smssync.Consts.MMS_PART;
 
 class MessageGenerator {
+    private static final String ERROR_PARSING_DATE = "error parsing date";
     private final Context mContext;
     private final HeaderGenerator mHeaderGenerator;
     private final Address mUserAddress;
@@ -97,7 +98,7 @@ class MessageGenerator {
         try {
             sentDate = new Date(Long.valueOf(msgMap.get(Telephony.TextBasedSmsColumns.DATE)));
         } catch (NumberFormatException n) {
-            Log.e(TAG, "error parsing date", n);
+            Log.e(TAG, ERROR_PARSING_DATE, n);
             sentDate = new Date();
         }
         mHeaderGenerator.setHeaders(msg, msgMap, DataType.SMS, address, record, sentDate, messageType);
@@ -135,7 +136,7 @@ class MessageGenerator {
         try {
             sentDate = new Date(1000 * Long.valueOf(msgMap.get(Telephony.BaseMmsColumns.DATE)));
         } catch (NumberFormatException n) {
-            Log.e(TAG, "error parsing date", n);
+            Log.e(TAG, ERROR_PARSING_DATE, n);
             sentDate = new Date();
         }
         final int msg_box = toInt(msgMap.get("msg_box"));
@@ -190,7 +191,7 @@ class MessageGenerator {
         try {
             sentDate = new Date(Long.valueOf(msgMap.get(CallLog.Calls.DATE)));
         } catch (NumberFormatException n) {
-            Log.e(TAG, "error parsing date", n);
+            Log.e(TAG, ERROR_PARSING_DATE, n);
             sentDate = new Date();
         }
         mHeaderGenerator.setHeaders(msg, msgMap, DataType.CALLLOG, address, record, sentDate, callType);

--- a/src/main/java/com/zegoggles/smssync/preferences/AuthPreferences.java
+++ b/src/main/java/com/zegoggles/smssync/preferences/AuthPreferences.java
@@ -20,6 +20,11 @@ import static com.zegoggles.smssync.App.TAG;
 import static com.zegoggles.smssync.preferences.ServerPreferences.Defaults.SERVER_PROTOCOL;
 
 public class AuthPreferences {
+    private static final String UTF_8 = "UTF-8";
+    private final Context context;
+    private final SharedPreferences preferences;
+    private final ServerPreferences serverPreferences;
+
     /**
      * Preference key containing the Google account username.
      */
@@ -49,10 +54,6 @@ public class AuthPreferences {
      * </ol>
      */
     private static final String IMAP_URI = "imap%s://%s:%s:%s@%s";
-
-    private final Context context;
-    private final SharedPreferences preferences;
-    private final ServerPreferences serverPreferences;
 
     public AuthPreferences(Context context) {
         this(context,  new ServerPreferences(context));
@@ -266,7 +267,7 @@ public class AuthPreferences {
         final String token = getOauth2Token();
         final String formatted = "user=" + username + "\001auth=Bearer " + token + "\001\001";
         try {
-            return new String(Base64.encodeBase64(formatted.getBytes("UTF-8")), "UTF-8");
+            return new String(Base64.encodeBase64(formatted.getBytes(UTF_8)), UTF_8);
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);
         }
@@ -274,7 +275,7 @@ public class AuthPreferences {
 
     private static String encode(String s) {
         try {
-            return s == null ? "" : URLEncoder.encode(s, "UTF-8");
+            return s == null ? "" : URLEncoder.encode(s, UTF_8);
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/com/zegoggles/smssync/preferences/Preferences.java
+++ b/src/main/java/com/zegoggles/smssync/preferences/Preferences.java
@@ -56,6 +56,7 @@ import static com.zegoggles.smssync.preferences.Preferences.Keys.THIRD_PARTY_INT
 import static com.zegoggles.smssync.preferences.Preferences.Keys.WIFI_ONLY;
 
 public class Preferences {
+    private static final String ERROR = "error";
     private final Context context;
     private final SharedPreferences preferences;
 
@@ -261,7 +262,7 @@ public class Preferences {
                     PackageManager.GET_META_DATA);
             return "" + (code ? pInfo.versionCode : pInfo.versionName);
         } catch (PackageManager.NameNotFoundException e) {
-            Log.e(TAG, "error", e);
+            Log.e(TAG, ERROR, e);
             return null;
         }
     }
@@ -276,7 +277,7 @@ public class Preferences {
 
             return (pInfo.applicationInfo.flags & ApplicationInfo.FLAG_EXTERNAL_STORAGE) != 0;
         } catch (PackageManager.NameNotFoundException e) {
-            Log.e(TAG, "error", e);
+            Log.e(TAG, ERROR, e);
             return false;
         }
     }
@@ -300,7 +301,7 @@ public class Preferences {
                     PackageManager.GET_META_DATA);
             code = pInfo.versionCode;
         } catch (PackageManager.NameNotFoundException e) {
-            Log.e(TAG, "error", e);
+            Log.e(TAG, ERROR, e);
             code = -1;
         }
 

--- a/src/main/java/com/zegoggles/smssync/service/BackupQueryBuilder.java
+++ b/src/main/java/com/zegoggles/smssync/service/BackupQueryBuilder.java
@@ -22,6 +22,7 @@ import static com.zegoggles.smssync.mail.DataType.MMS;
 import static com.zegoggles.smssync.mail.DataType.SMS;
 
 class BackupQueryBuilder {
+    private static final String DESC_LIMIT_1 = " DESC LIMIT 1";
     private final Context context;
 
     // only query for needed fields
@@ -76,21 +77,21 @@ class BackupQueryBuilder {
                     new String[] {Telephony.BaseMmsColumns.DATE },
                     null,
                     null,
-                    Telephony.BaseMmsColumns.DATE + " DESC LIMIT 1");
+                    Telephony.BaseMmsColumns.DATE + DESC_LIMIT_1);
             case SMS:
                 return new Query(
                     Consts.SMS_PROVIDER,
                     new String[]{Telephony.TextBasedSmsColumns.DATE},
                     Telephony.TextBasedSmsColumns.TYPE + " <> ?",
                     new String[]{String.valueOf(Telephony.TextBasedSmsColumns.MESSAGE_TYPE_DRAFT)},
-                    Telephony.TextBasedSmsColumns.DATE + " DESC LIMIT 1");
+                    Telephony.TextBasedSmsColumns.DATE + DESC_LIMIT_1);
             case CALLLOG:
                 return new Query(
                     Consts.CALLLOG_PROVIDER,
                     new String[]{CallLog.Calls.DATE},
                     null,
                     null,
-                    CallLog.Calls.DATE + " DESC LIMIT 1");
+                    CallLog.Calls.DATE + DESC_LIMIT_1);
             default:
                 return null;
         }

--- a/src/main/java/com/zegoggles/smssync/service/RestoreTask.java
+++ b/src/main/java/com/zegoggles/smssync/service/RestoreTask.java
@@ -45,6 +45,7 @@ import static com.zegoggles.smssync.service.state.SmsSyncState.RESTORE;
 import static com.zegoggles.smssync.service.state.SmsSyncState.UPDATING_THREADS;
 
 class RestoreTask extends AsyncTask<RestoreConfig, RestoreState, RestoreState> {
+    private static final String ERROR = "error";
     private Set<String> smsIds = new HashSet<String>();
     private Set<String> callLogIds = new HashSet<String>();
     private Set<String> uids = new HashSet<String>();
@@ -135,14 +136,14 @@ class RestoreTask extends AsyncTask<RestoreConfig, RestoreState, RestoreState> {
         } catch (XOAuth2AuthenticationFailedException e) {
             return handleAuthError(config, currentRestoredItem, e);
         } catch (AuthenticationFailedException e) {
-            return transition(ERROR, e);
+            return transition(SmsSyncState.ERROR, e);
         } catch (MessagingException e) {
-            Log.e(TAG, "error", e);
+            Log.e(TAG, ERROR, e);
             updateAllThreadsIfAnySmsRestored();
-            return transition(ERROR, e);
+            return transition(SmsSyncState.ERROR, e);
         } catch (IllegalStateException e) {
             // usually memory problems (Couldn't init cursor window)
-            return transition(ERROR, e);
+            return transition(SmsSyncState.ERROR, e);
         } finally {
             imapStore.closeFolders();
         }
@@ -168,7 +169,7 @@ class RestoreTask extends AsyncTask<RestoreConfig, RestoreState, RestoreState> {
         } else {
             Log.w(TAG, "unexpected xoauth status code " + e.getStatus());
         }
-        return transition(ERROR, e);
+        return transition(SmsSyncState.ERROR, e);
     }
 
     private void publishProgress(SmsSyncState smsSyncState) {
@@ -234,12 +235,12 @@ class RestoreTask extends AsyncTask<RestoreConfig, RestoreState, RestoreState> {
             }
 
         } catch (MessagingException e) {
-            Log.e(TAG, "error", e);
+            Log.e(TAG, ERROR, e);
         } catch (IllegalArgumentException e) {
             // http://code.google.com/p/android/issues/detail?id=2916
-            Log.e(TAG, "error", e);
+            Log.e(TAG, ERROR, e);
         } catch (IOException e) {
-            Log.e(TAG, "error", e);
+            Log.e(TAG, ERROR, e);
         }
         return dataType;
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1192 - String literals should not be duplicated.
This pull request removes 68 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1192
Please let me know if you have any questions.
George Kankava