### PR TITLE
squid:MissingDeprecatedCheck - Deprecated elements should have both the annotation and the Javadoc tag

### DIFF
--- a/src/main/java/com/zegoggles/smssync/MmsConsts.java
+++ b/src/main/java/com/zegoggles/smssync/MmsConsts.java
@@ -26,6 +26,9 @@ public interface MmsConsts {
 
     String DELIVERY_REPORT = "134"; // 0x86
 
+    /**
+     * @deprecated kept for backwards compatibility
+     */
     @Deprecated
     String LEGACY_HEADER = "mms";
 }

--- a/src/main/java/com/zegoggles/smssync/auth/XOAuthConsumer.java
+++ b/src/main/java/com/zegoggles/smssync/auth/XOAuthConsumer.java
@@ -68,6 +68,9 @@ import static oauth.signpost.OAuth.ENCODING;
 import static oauth.signpost.OAuth.OAUTH_SIGNATURE;
 import static oauth.signpost.OAuth.percentEncode;
 
+/**
+ * @deprecated This class is deprecated and is kept for backwards compatibility
+ */
 @Deprecated
 public class XOAuthConsumer extends CommonsHttpOAuthConsumer {
     private static final String MAC_NAME = "HmacSHA1";

--- a/src/main/java/com/zegoggles/smssync/preferences/AuthPreferences.java
+++ b/src/main/java/com/zegoggles/smssync/preferences/AuthPreferences.java
@@ -43,8 +43,17 @@ public class AuthPreferences {
      */
     public static final String LOGIN_PASSWORD = "login_password";
     public static final String SERVER_AUTHENTICATION = "server_authentication";
+    /**
+     * @deprecated kept for backwards compatibility
+     */
     @Deprecated private static final String OAUTH_TOKEN = "oauth_token";
+    /**
+     * @deprecated kept for backwards compatibility
+     */
     @Deprecated private static final String OAUTH_TOKEN_SECRET = "oauth_token_secret";
+    /**
+     * @deprecated kept for backwards compatibility
+     */
     @Deprecated private static final String OAUTH_USER = "oauth_user";
     private static final String OAUTH2_USER = "oauth2_user";
     private static final String OAUTH2_TOKEN = "oauth2_token";
@@ -64,6 +73,9 @@ public class AuthPreferences {
      */
     private static final String IMAP_URI = "imap%s://%s:%s:%s@%s";
 
+    /**
+     * @deprecated kept for backwards compatibility
+     */
     @Deprecated
     public XOAuthConsumer getOAuthConsumer() {
         return new XOAuthConsumer(
@@ -80,6 +92,9 @@ public class AuthPreferences {
         return getCredentials().getString(OAUTH2_REFRESH_TOKEN, null);
     }
 
+    /**
+     * @deprecated kept for backwards compatibility
+     */
     @Deprecated
     public boolean hasOauthTokens() {
         return getOauthUsername() != null &&
@@ -113,6 +128,9 @@ public class AuthPreferences {
                 .commit();
     }
 
+    /**
+     * @deprecated kept for backwards compatibility
+     */
     @Deprecated
     public void clearOAuth1Data() {
         preferences.edit().remove(OAUTH_USER).commit();
@@ -203,16 +221,25 @@ public class AuthPreferences {
                 serverPreferences.getServerAddress());
     }
 
+    /**
+     * @deprecated kept for backwards compatibility
+     */
     @Deprecated
     private String getOauthTokenSecret() {
         return getCredentials().getString(OAUTH_TOKEN_SECRET, null);
     }
 
+    /**
+     * @deprecated kept for backwards compatibility
+     */
     @Deprecated
     private String getOauthToken() {
         return getCredentials().getString(OAUTH_TOKEN, null);
     }
 
+    /**
+     * @deprecated kept for backwards compatibility
+     */
     @Deprecated
     private String getOauthUsername() {
         return preferences.getString(OAUTH_USER, null);

--- a/src/main/java/com/zegoggles/smssync/service/SmsBackupService.java
+++ b/src/main/java/com/zegoggles/smssync/service/SmsBackupService.java
@@ -294,6 +294,9 @@ public class SmsBackupService extends ServiceBase {
         return mState.transition(newState, e);
     }
 
+    /**
+     * @deprecated kept for backwards compatibility
+     */
     @Deprecated
     private void runMigration() {
         appLogDebug("running OAuth1 migration");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:MissingDeprecatedCheck - Deprecated elements should have both the annotation and the Javadoc tag.
This pull request removes 60 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:MissingDeprecatedCheck
Please let me know if you have any questions.
George Kankava