### PR TITLE
Encrypt backed up messages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.sufficientlysecure</groupId>
+            <artifactId>openpgp-api</artifactId>
+            <type>aar</type>
+            <version>8.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.github.jberkel.pay.me</groupId>
             <artifactId>library</artifactId>
             <version>0.0.4</version>
@@ -221,6 +228,17 @@
         <repository>
             <id>bintray</id>
             <url>https://dl.bintray.com/jberkel/maven</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+
+        <repository>
+            <id>bintray-openpgp</id>
+            <url>https://dl.bintray.com/sufficientlysecure/maven/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -330,6 +330,14 @@
   </string>
   <string name="select_google_account">Select a Google account</string>
 
+  <!-- encryption strings -->
+  <string name="ui_encryption_title">Encryption</string>
+  <string name="ui_encryption_desc">Encrypt backed up messages.</string>
+  <string name="ui_encryption_selectprov">Select OpenPGP Provider</string>
+  <string name="ui_encryption_noprov">No provider selected.</string>
+  <string name="ui_encryption_prov">PGP provider:\u0020</string>
+  <string name="ui_encryption_missingprov">Your chosen PGP provider does not appear to be installed.</string>
+
   <!-- donation related -->
   <string name="donate">Donate</string>
   <string name="donate_summary">Using secure Google Play Store in-app payment.</string>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -220,6 +220,20 @@
 
         </PreferenceScreen>
 
+        <PreferenceScreen
+            android:key="encryption"
+            android:title="@string/ui_encryption_title"
+            android:summary="@string/ui_encryption_desc">
+            <org.openintents.openpgp.util.OpenPgpAppPreference
+                android:key="openpgp_provider_list"
+                android:title="@string/ui_encryption_selectprov"
+                android:summary="@string/ui_encryption_noprov"
+                android:defaultValue=""/>
+            <org.openintents.openpgp.util.OpenPgpKeyPreference
+                android:key="pgp_keys"
+                android:title="Select Keys"/>
+        </PreferenceScreen>
+
         <CheckBoxPreference
                 android:key="notifications"
                 android:title="@string/ui_notifications_label"

--- a/src/main/java/com/zegoggles/smssync/mail/MessageConverter.java
+++ b/src/main/java/com/zegoggles/smssync/mail/MessageConverter.java
@@ -50,6 +50,8 @@ import java.util.Random;
 import static com.zegoggles.smssync.App.LOCAL_LOGV;
 import static com.zegoggles.smssync.App.TAG;
 
+import org.openintents.openpgp.util.OpenPgpServiceConnection;
+
 public class MessageConverter {
     //ContactsContract.CommonDataKinds.Email.CONTENT_URI
     public static final Uri ECLAIR_CONTENT_URI =
@@ -66,7 +68,8 @@ public class MessageConverter {
     public MessageConverter(Context context, Preferences preferences,
                             String userEmail,
                             PersonLookup personLookup,
-                            ContactAccessor contactAccessor) {
+                            ContactAccessor contactAccessor,
+                            OpenPgpServiceConnection serviceConnection) {
         mContext = context;
         mMarkAsReadType = preferences.getMarkAsReadType();
         mPersonLookup = personLookup;
@@ -89,7 +92,8 @@ public class MessageConverter {
                 mPersonLookup,
                 preferences.getMailSubjectPrefix(),
                 allowedIds,
-                new MmsSupport(mContext.getContentResolver(), mPersonLookup));
+                new MmsSupport(mContext.getContentResolver(), mPersonLookup),
+                serviceConnection);
     }
 
     private boolean markAsSeen(DataType dataType, Map<String, String> msgMap) {

--- a/src/main/java/com/zegoggles/smssync/preferences/Preferences.java
+++ b/src/main/java/com/zegoggles/smssync/preferences/Preferences.java
@@ -23,6 +23,7 @@ import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.preference.PreferenceManager;
+import android.text.TextUtils;
 import android.util.Log;
 import com.zegoggles.smssync.contacts.ContactGroup;
 import com.zegoggles.smssync.mail.DataType;
@@ -37,6 +38,8 @@ import static com.zegoggles.smssync.preferences.Preferences.Keys.CALLLOG_SYNC_CA
 import static com.zegoggles.smssync.preferences.Preferences.Keys.CALLLOG_SYNC_CALENDAR_ENABLED;
 import static com.zegoggles.smssync.preferences.Preferences.Keys.CONFIRM_ACTION;
 import static com.zegoggles.smssync.preferences.Preferences.Keys.ENABLE_AUTO_BACKUP;
+import static com.zegoggles.smssync.preferences.Preferences.Keys.ENCRYPTION_PROVIDER;
+import static com.zegoggles.smssync.preferences.Preferences.Keys.ENCRYPTION_KEYS;
 import static com.zegoggles.smssync.preferences.Preferences.Keys.FIRST_USE;
 import static com.zegoggles.smssync.preferences.Preferences.Keys.INCOMING_TIMEOUT_SECONDS;
 import static com.zegoggles.smssync.preferences.Preferences.Keys.LAST_VERSION_CODE;
@@ -78,6 +81,8 @@ public class Preferences {
         WIFI_ONLY("wifi_only"),
         REFERENCE_UID("reference_uid"),
         MAIL_SUBJECT_PREFIX("mail_subject_prefix"),
+        ENCRYPTION_PROVIDER("openpgp_provider_list"),
+        ENCRYPTION_KEYS("pgp_keys"),
         RESTORE_STARRED_ONLY("restore_starred_only"),
         @Deprecated
         MARK_AS_READ("mark_as_read"),
@@ -211,6 +216,26 @@ public class Preferences {
                 return false;
             }
         }
+        return true;
+    }
+
+    public String getEncryptionProvider() {
+        return preferences.getString(ENCRYPTION_PROVIDER.key, "");
+    }
+
+    public long[] getEncryptionKeyID() {
+        long[] retval = new long[1];
+        retval[0] = preferences.getLong(ENCRYPTION_KEYS.key, 0);
+        return retval;
+    }
+
+    public boolean isEncryptionAvailable() {
+		if (TextUtils.isEmpty(getEncryptionProvider()))
+            return false;
+
+        if (getEncryptionKeyID()[0] == 0)
+            return false;
+
         return true;
     }
 

--- a/src/main/java/com/zegoggles/smssync/service/SmsRestoreService.java
+++ b/src/main/java/com/zegoggles/smssync/service/SmsRestoreService.java
@@ -85,7 +85,8 @@ public class SmsRestoreService extends ServiceBase {
                     getPreferences(),
                     getAuthPreferences().getUserEmail(),
                     new PersonLookup(getContentResolver()),
-                    ContactAccessor.Get.instance()
+                    ContactAccessor.Get.instance(),
+                    null
             );
 
             RestoreConfig config = new RestoreConfig(

--- a/src/test/java/com/zegoggles/smssync/mail/MessageConverterTest.java
+++ b/src/test/java/com/zegoggles/smssync/mail/MessageConverterTest.java
@@ -41,7 +41,7 @@ public class MessageConverterTest {
         initMocks(this);
         BinaryTempFileBody.setTempDirectory(Robolectric.application.getCacheDir());
         messageConverter = new MessageConverter(Robolectric.application,
-                preferences, "foo@example.com", personLookup, contactAccessor);
+                preferences, "foo@example.com", personLookup, contactAccessor, null);
     }
 
     @Test(expected = MessagingException.class)
@@ -116,7 +116,7 @@ public class MessageConverterTest {
         when(preferences.getMarkAsReadType()).thenReturn(MarkAsReadTypes.MESSAGE_STATUS);
 
         messageConverter = new MessageConverter(Robolectric.application,
-                preferences, "foo@example.com", personLookup, contactAccessor);
+                preferences, "foo@example.com", personLookup, contactAccessor, null);
 
         ConversionResult res = messageConverter.convertMessages(cursor, DataType.SMS);
         assertThat(res.getMessages().get(0).isSet(Flag.SEEN)).isFalse();
@@ -138,7 +138,7 @@ public class MessageConverterTest {
         when(preferences.getMarkAsReadType()).thenReturn(MarkAsReadTypes.UNREAD);
 
         messageConverter = new MessageConverter(Robolectric.application,
-                preferences, "foo@example.com", personLookup, contactAccessor);
+                preferences, "foo@example.com", personLookup, contactAccessor, null);
 
         ConversionResult res = messageConverter.convertMessages(cursor, DataType.SMS);
         assertThat(res.getMessages().get(0).isSet(Flag.SEEN)).isFalse();
@@ -160,7 +160,7 @@ public class MessageConverterTest {
         when(preferences.getMarkAsReadType()).thenReturn(MarkAsReadTypes.READ);
 
         messageConverter = new MessageConverter(Robolectric.application,
-                preferences, "foo@example.com", personLookup, contactAccessor);
+                preferences, "foo@example.com", personLookup, contactAccessor, null);
 
         ConversionResult res = messageConverter.convertMessages(cursor, DataType.SMS);
         assertThat(res.getMessages().get(0).isSet(Flag.SEEN)).isTrue();

--- a/src/test/java/com/zegoggles/smssync/mail/MessageGeneratorTest.java
+++ b/src/test/java/com/zegoggles/smssync/mail/MessageGeneratorTest.java
@@ -48,7 +48,8 @@ public class MessageGeneratorTest {
                 personLookup,
                 false,
                 null,
-                mmsSupport
+                mmsSupport,
+                null
         );
     }
 
@@ -216,7 +217,8 @@ public class MessageGeneratorTest {
                 personLookup,
                 false,
                 groupIds,
-                mmsSupport
+                mmsSupport,
+                null
         );
         PersonRecord record = new PersonRecord(1, "Test Testor", "test@test.com", "1234");
         Map<String, String> map = mockMessage("1234", record);

--- a/src/test/java/com/zegoggles/smssync/service/BackupTaskTest.java
+++ b/src/test/java/com/zegoggles/smssync/service/BackupTaskTest.java
@@ -28,6 +28,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
+import org.openintents.openpgp.util.OpenPgpServiceConnection;
 
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -67,6 +68,7 @@ public class BackupTaskTest {
     @Mock Preferences preferences;
     @Mock ContactAccessor accessor;
     @Mock TokenRefresher tokenRefresher;
+    @Mock OpenPgpServiceConnection serviceConnection;
 
     @Before public void before() {
         initMocks(this);
@@ -74,7 +76,7 @@ public class BackupTaskTest {
         when(service.getApplicationContext()).thenReturn(Robolectric.application);
         when(service.getState()).thenReturn(state);
 
-        task = new BackupTask(service, fetcher, converter, syncer, authPreferences, preferences, accessor, tokenRefresher);
+        task = new BackupTask(service, fetcher, converter, syncer, authPreferences, preferences, accessor, tokenRefresher, serviceConnection);
         context = Robolectric.application;
     }
 


### PR DESCRIPTION
These patches allow using the openpgp android API to encrypt backed up messages (SMS only, no decryption on restore).

I've been using these patches for years. I've taken the experimental decryption stuff out from my old git repo, as I haven't had a chance to finish it, and have never really needed it. Maybe I'll get round to it some day, as well as encrypting MMS messages! Most important to me is SMS encryption though, because it prevents a compromised email address being used to get round two-factor authentication or account recovery using SMS for any other service which knows the user's phone number.