### PR TITLE
Allow installation to external media

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,7 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools"
           package="com.zegoggles.smssync"
-          android:description="@string/app_description">
+          android:description="@string/app_description"
+          android:installLocation="auto">
 
     <!-- “dangerous” permissions -->
 


### PR DESCRIPTION
This change will enable installation of the app to external as well as internal flash memory which is important for devices where internal memory is limited but external memory is cheap and abundant in form of micro SD cards.  Thank you for your consideration.