### PR TITLE
Fix a too specific error string about IMAP failure

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -71,7 +71,7 @@
   <string name="status_calc_details">Calculating\u2026</string>
   <string name="status_canceled">Canceled</string>
   <string name="status_canceled_details">%1$d/%2$d items successfully backed up.</string>
-  <string name="status_gmail_temp_error">Temporary Gmail IMAP error, try again later.</string>
+  <string name="status_gmail_temp_error">Temporary IMAP error, try again later.</string>
 
   <string name="ui_settings_advanced_label">Advanced settings</string>
   <string name="ui_settings_advanced_desc">Set advanced preferences.</string>

--- a/app/src/test/java/com/zegoggles/smssync/service/state/StateTest.java
+++ b/app/src/test/java/com/zegoggles/smssync/service/state/StateTest.java
@@ -63,7 +63,7 @@ public class StateTest {
         BackupState state = new BackupState(SmsSyncState.ERROR, 0, 0,
                 BackupType.REGULAR, DataType.SMS, new MessagingException("Unable to get IMAP prefix"));
 
-        assertThat(state.getErrorMessage(resources)).isEqualTo("Temporary Gmail IMAP error, try again later.");
+        assertThat(state.getErrorMessage(resources)).isEqualTo("Temporary IMAP error, try again later.");
     }
 
     @Test public void shouldGetNotificationLabelLogin() throws Exception {


### PR DESCRIPTION
I use my own IMAP server instead of GMail and I got a notification reading:

    Temporary Gmail IMAP error, try again later.

I was confused at first. Then I realized that an assumption is that everyone uses GMail, even though the app works just fine with any other IMAP server.

This error message is too specific as it applies to a failure with any IMAP server, and not just GMail. The patch makes the message more general, which makes it applicable to all app users.