### PR TITLE
Handle RCS messages properly, and improve group MMS

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,8 +47,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_6
-        targetCompatibility JavaVersion.VERSION_1_6
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,6 +16,7 @@ android {
         versionCode 1602
         versionName '1.6.0-BETA2'
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
+        ndk.abiFilters 'armeabi-v7a','arm64-v8a'
     }
 
     signingConfigs {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -56,7 +56,7 @@ android {
 dependencies {
     implementation 'com.squareup:otto:1.3.8'
     implementation 'com.github.jberkel.k-9:k9mail-library:eaf689025e'
-    implementation 'com.android.billingclient:billing:2.0.3'
+    implementation 'com.android.billingclient:billing:2.1.0'
     implementation 'com.firebase:firebase-jobdispatcher:0.8.6'
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'androidx.preference:preference:1.1.0'

--- a/app/src/main/java/com/zegoggles/smssync/mail/HeaderGenerator.java
+++ b/app/src/main/java/com/zegoggles/smssync/mail/HeaderGenerator.java
@@ -2,6 +2,8 @@ package com.zegoggles.smssync.mail;
 
 import android.provider.CallLog;
 import android.provider.Telephony;
+import android.util.Log;
+
 import androidx.annotation.NonNull;
 import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.MessagingException;
@@ -14,6 +16,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
 
+import static com.zegoggles.smssync.App.TAG;
 import static com.zegoggles.smssync.utils.Sanitizer.sanitize;
 
 /**
@@ -36,12 +39,11 @@ class HeaderGenerator {
                            final Map<String, String> msgMap,
                            final DataType dataType,
                            final String address,
-                           final @NonNull PersonRecord contact,
+                           final String referenceId,
                            final Date sentDate,
                            final int status) throws MessagingException {
 
-        // Threading by contact ID, not by thread ID. I think this value is more stable.
-        message.setHeader(Headers.REFERENCES, String.format(REFERENCE_UID_TEMPLATE, reference, contact.getId()));
+        message.setHeader(Headers.REFERENCES, String.format(REFERENCE_UID_TEMPLATE, reference, referenceId));
         message.setHeader(Headers.MESSAGE_ID, createMessageId(sentDate, address, status));
         message.setHeader(Headers.ADDRESS,  sanitize(address));
         message.setHeader(Headers.DATATYPE, dataType.toString());

--- a/app/src/main/java/com/zegoggles/smssync/mail/HeaderGenerator.java
+++ b/app/src/main/java/com/zegoggles/smssync/mail/HeaderGenerator.java
@@ -44,7 +44,10 @@ class HeaderGenerator {
                            final int status) throws MessagingException {
 
         message.setHeader(Headers.REFERENCES, String.format(REFERENCE_UID_TEMPLATE, reference, referenceId));
-        message.setHeader(Headers.MESSAGE_ID, createMessageId(sentDate, address, status));
+        // "v2" effectively versions how we hash each message.
+        // This goes along with a fix for how MMS messages are grouped, and allows users to
+        // reset the app state and re-backup their existing messages to fix older threads.
+        message.setHeader(Headers.MESSAGE_ID, createMessageId(sentDate, address + "v2", status));
         message.setHeader(Headers.ADDRESS,  sanitize(address));
         message.setHeader(Headers.DATATYPE, dataType.toString());
         message.setHeader(Headers.BACKUP_TIME, toGMTString(new Date()));

--- a/app/src/main/java/com/zegoggles/smssync/mail/MessageGenerator.java
+++ b/app/src/main/java/com/zegoggles/smssync/mail/MessageGenerator.java
@@ -141,7 +141,6 @@ class MessageGenerator {
         if (details.inbound) {
             // msg_box == MmsConsts.MESSAGE_BOX_INBOX does not work
             msg.setFrom(details.getSender().getAddress(addressStyle));
-//            msg.setRecipient(Message.RecipientType.TO, userAddress); // first attempt. Makes it look like the MMS only went to me, not to many people.
             msg.setRecipients(Message.RecipientType.TO, details.getRecipientAddresses(addressStyle)); // Includes everyone that received the MMS in the email "to" field.
         } else {
             msg.setRecipients(Message.RecipientType.TO, details.getRecipientAddresses(addressStyle));
@@ -239,7 +238,7 @@ class MessageGenerator {
 
     private String getSubject(@NonNull DataType type, @NonNull MmsSupport.MmsDetails details) {
         // If you're in a group text with several people, ensure the email subject will look like
-        // "SMS with Alice/Bob/Charles/YourName"
+        // "SMS with Alice/Bob/Charles/YourPhoneNumber"
 
         Set<String> allNames = new HashSet<>(); // eliminate duplicates. There will be some - android's MMS apis are weird.
 

--- a/app/src/main/java/com/zegoggles/smssync/mail/MmsSupport.java
+++ b/app/src/main/java/com/zegoggles/smssync/mail/MmsSupport.java
@@ -134,6 +134,20 @@ class MmsSupport {
             inbound = false;
         }
 
+        // Strip recipient if it's also the sender. Ensures that incoming messages in RCS threads
+        // between 2 people don't include your own phone number, so that the thread doesn't get split.
+        if (sender != null) {
+            List<PersonRecord> recipientsWithoutSender = new ArrayList<>();
+
+            for (PersonRecord recipient : recipients) {
+                if (!recipient.getId().equals(sender.getId())) {
+                    recipientsWithoutSender.add(recipient);
+                }
+            }
+
+            recipients = recipientsWithoutSender;
+        }
+
         return new MmsDetails(inbound, sender, recipients, rawAddresses);
     }
 

--- a/app/src/main/java/com/zegoggles/smssync/mail/MmsSupport.java
+++ b/app/src/main/java/com/zegoggles/smssync/mail/MmsSupport.java
@@ -106,12 +106,13 @@ class MmsSupport {
             // https://stackoverflow.com/questions/52186442/how-to-get-phone-numbers-of-mms-group-conversation-participants
             String PduHeadersFROM  = "137";
             String PduHeadersTO  = "151";
+            String PduHeadersCC  = "130"; // https://android.googlesource.com/platform/frameworks/opt/mms/+/4bfcd8501f09763c10255442c2b48fad0c796baa/src/java/com/google/android/mms/pdu/PduHeaders.java
 
             String type = cursor.getString(cursor.getColumnIndex("type"));
             if (type.equals(PduHeadersFROM)) {
                 PersonRecord record = personLookup.lookupPerson(address);
                 sender = record;
-            } else if (type.equals(PduHeadersTO)) {
+            } else if (type.equals(PduHeadersTO) || type.equals(PduHeadersCC)) {
                 PersonRecord record = personLookup.lookupPerson(address);
                 recipients.add(record);
             } else {

--- a/app/src/main/java/com/zegoggles/smssync/mail/MmsSupport.java
+++ b/app/src/main/java/com/zegoggles/smssync/mail/MmsSupport.java
@@ -3,9 +3,11 @@ package com.zegoggles.smssync.mail;
 import android.content.ContentResolver;
 import android.database.Cursor;
 import android.net.Uri;
-import androidx.annotation.NonNull;
 import android.text.TextUtils;
 import android.util.Log;
+
+import androidx.annotation.NonNull;
+
 import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.BodyPart;
 import com.fsck.k9.mail.MessagingException;
@@ -16,7 +18,6 @@ import com.zegoggles.smssync.MmsConsts;
 import com.zegoggles.smssync.preferences.AddressStyle;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
@@ -36,51 +37,52 @@ class MmsSupport {
 
     static class MmsDetails {
         public final boolean inbound;
-        public final List<String> recipients;
-        public final List<PersonRecord> records;
-        public final List<Address> addresses;
-
-        public final String address;
-
+        public final PersonRecord sender;
+        public final List<PersonRecord> recipients;
+        public final  String firstRawAddress;
 
         public MmsDetails(boolean inbound,
-                          @NonNull List<String> recipients,
-                          List<PersonRecord> records,
-                          List<Address> addresses) {
+                          PersonRecord sender,
+                          @NonNull List<PersonRecord> recipients,
+                          String firstRawAddress) {
 
-            if (recipients.isEmpty()) {
-                address = "Unknown";
-            } else {
-                address = recipients.get(0);
+            if (firstRawAddress == null) {
+                firstRawAddress = "Unknown";
             }
 
-            this.recipients = recipients;
             this.inbound = inbound;
-            this.records = records;
-            this.addresses = addresses;
-        }
-
-        public MmsDetails(boolean inbound,
-                          String recipient,
-                          PersonRecord record,
-                          Address address) {
-            this(inbound, Arrays.asList(recipient), Arrays.asList(record), Arrays.asList(address));
+            this.sender = sender;
+            this.recipients = recipients;
+            this.firstRawAddress = firstRawAddress;
         }
 
         public boolean isEmpty() {
             return recipients.isEmpty();
         }
 
-        public Address[] getAddresses() {
-            return addresses.toArray(new Address[addresses.size()]);
+        public PersonRecord getSender() {
+            return sender;
+        }
+
+        public List<PersonRecord> getRecipients() {
+            return recipients;
+        }
+
+        public Address[] getRecipientAddresses(AddressStyle style) {
+            List<Address> recipientAddresses = new ArrayList<>(recipients.size());
+            for (PersonRecord recipient : recipients) {
+                recipientAddresses.add(recipient.getAddress(style));
+            }
+
+            return recipientAddresses.toArray(new Address[0]);
         }
 
         public PersonRecord getRecipient() {
-            return records.get(0);
+            return recipients.get(0);
         }
 
-        public Address getRecipientAddress() {
-            return addresses.get(0);
+        public String getFirstRawAddress() {
+            return firstRawAddress;
         }
     }
 
@@ -88,30 +90,44 @@ class MmsSupport {
 
         Cursor cursor = resolver.query(Uri.withAppendedPath(mmsUri, "addr"), null, null, null, null);
 
-        // TODO: this is probably not the best way to determine if a message is inbound or outbound
         boolean inbound = true;
-        final List<String> recipients = new ArrayList<String>();
+        List<PersonRecord> recipients = new ArrayList<PersonRecord>();
+        PersonRecord sender = null;
+
+        String firstRawAddress = null;
+
         while (cursor != null && cursor.moveToNext()) {
             final String address = cursor.getString(cursor.getColumnIndex("address"));
-            //final int type       = addresses.getInt(addresses.getColumnIndex("type"));
-            if (MmsConsts.INSERT_ADDRESS_TOKEN.equals(address)) {
-                inbound = false;
+
+            if (firstRawAddress == null) {
+                firstRawAddress = address;
+            }
+
+            // https://stackoverflow.com/questions/52186442/how-to-get-phone-numbers-of-mms-group-conversation-participants
+            String PduHeadersFROM  = "137";
+            String PduHeadersTO  = "151";
+
+            String type = cursor.getString(cursor.getColumnIndex("type"));
+            if (type.equals(PduHeadersFROM)) {
+                PersonRecord record = personLookup.lookupPerson(address);
+                sender = record;
+            } else if (type.equals(PduHeadersTO)) {
+                PersonRecord record = personLookup.lookupPerson(address);
+                recipients.add(record);
             } else {
-                recipients.add(address);
+                Log.w(TAG, "New logic for to/from did not work, falling back to old logic");
+
+                if (MmsConsts.INSERT_ADDRESS_TOKEN.equals(address)) {
+                    inbound = false;
+                } else {
+                    PersonRecord record = personLookup.lookupPerson(address);
+                    recipients.add(record);
+                }
             }
         }
         if (cursor != null) cursor.close();
 
-        List<PersonRecord> records = new ArrayList<PersonRecord>(recipients.size());
-        List<Address> addresses = new ArrayList<Address>(recipients.size());
-        if (!recipients.isEmpty()) {
-            for (String s : recipients) {
-                PersonRecord record = personLookup.lookupPerson(s);
-                records.add(record);
-                addresses.add(record.getAddress(style));
-            }
-        }
-        return new MmsDetails(inbound, recipients, records, addresses);
+        return new MmsDetails(inbound, sender, recipients, firstRawAddress);
     }
 
     public List<BodyPart> getMMSBodyParts(final Uri uriPart) throws MessagingException {

--- a/app/src/main/java/com/zegoggles/smssync/mail/MmsSupport.java
+++ b/app/src/main/java/com/zegoggles/smssync/mail/MmsSupport.java
@@ -39,21 +39,17 @@ class MmsSupport {
         public final boolean inbound;
         public final PersonRecord sender;
         public final List<PersonRecord> recipients;
-        public final  String firstRawAddress;
+        public final List<String> rawAddresses;
 
         public MmsDetails(boolean inbound,
                           PersonRecord sender,
                           @NonNull List<PersonRecord> recipients,
-                          String firstRawAddress) {
-
-            if (firstRawAddress == null) {
-                firstRawAddress = "Unknown";
-            }
+                          List<String> rawAddresses) {
 
             this.inbound = inbound;
             this.sender = sender;
             this.recipients = recipients;
-            this.firstRawAddress = firstRawAddress;
+            this.rawAddresses = rawAddresses;
         }
 
         public boolean isEmpty() {
@@ -82,7 +78,11 @@ class MmsSupport {
         }
 
         public String getFirstRawAddress() {
-            return firstRawAddress;
+            if (rawAddresses.size() == 0) {
+                return  "Unknown";
+            }
+
+            return rawAddresses.get(0);
         }
     }
 
@@ -94,14 +94,12 @@ class MmsSupport {
         List<PersonRecord> recipients = new ArrayList<PersonRecord>();
         PersonRecord sender = null;
 
-        String firstRawAddress = null;
+        List<String> rawAddresses = new ArrayList<>();
 
         while (cursor != null && cursor.moveToNext()) {
             final String address = cursor.getString(cursor.getColumnIndex("address"));
 
-            if (firstRawAddress == null) {
-                firstRawAddress = address;
-            }
+            rawAddresses.add(address);
 
             // https://stackoverflow.com/questions/52186442/how-to-get-phone-numbers-of-mms-group-conversation-participants
             String PduHeadersFROM  = "137";
@@ -127,7 +125,7 @@ class MmsSupport {
         }
         if (cursor != null) cursor.close();
 
-        return new MmsDetails(inbound, sender, recipients, firstRawAddress);
+        return new MmsDetails(inbound, sender, recipients, rawAddresses);
     }
 
     public List<BodyPart> getMMSBodyParts(final Uri uriPart) throws MessagingException {

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.0-beta05'
+        classpath 'com.android.tools.build:gradle:4.1.3'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ buildscript {
     repositories {
         google()
         jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'
@@ -18,8 +19,12 @@ allprojects {
 
     repositories {
         jcenter()
+        mavenCentral()
         maven { url "https://maven.google.com" }
         maven { url "https://jitpack.io" }
+        maven { url "https://jcenter.bintray.com" }
+        //  This is the only repo that seems to be hosting "com.firebase:firebase-jobdispatcher" in 2024
+        maven { url "https://maven.scijava.org/content/repositories/public/" }
         google()
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,4 +16,3 @@ android.useAndroidX=true
 android.enableJetifier=true
 # https://github.com/robolectric/robolectric/issues/5299
 android.jetifier.blacklist=.*bcprov.*
-android.enableSeparateAnnotationProcessing=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Apr 06 02:12:29 CEST 2019
+#Sat Apr 22 23:40:26 CDT 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Sat Apr 22 23:40:26 CDT 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip


### PR DESCRIPTION
Fixes #1055 and #1027

This fixes RCS importing 🎉 

It also improves how group MMS threads are imported. Basically it includes all the recipients in the "to" field, and puts everyone's name in the subject, so that gmail does a much better job mimicking the group threads on your phone.

I've been toying around with it on my Pixel 3a running Android 10. I've tested with a mix of SMS, group MMS chats, and RCS chats.

I'm completely open to the idea that I was a little heavy-handed with my refactor. I ran with what made sense. I'm fine if someone else wants to take this as as proof-of-concept and run in a slightly different direction to make this mergeable.

TODO
- [ ] See if there are any unit tests that have been broken
- [ ] Probably some new unit tests (to be honest..... I really don't want to build these out).
- [x] Give this another look over for general code quality. The old version of Java (and me being a bit rusty with Java) made some things like sets/arrays/uniq/etc a bit clunky.


## Testing

Tips for testing:
- If you want to try running this multiple times and tweaking how we generate ids/subjects/etc, make sure to delete your emails generated from testing AND empty gmail's trash. Otherwise gmail will cache things. I saw it caching the REFERENCES field when I re-used the same MESSAGE_ID.
- Once you've identified some messages on your phone for a certain test case, it can be helpful to _just_ process those messages. You can hardcode timestamps in the queries in `app/src/main/java/com/zegoggles/smssync/service/BackupQueryBuilder.java`. https://www.epochconverter.com/ is your friend here.

Some test cases that I've gone through on my phone, and verified that the backup looks correct in Gmail:
- RCS message with 1 person. **working as of bec0a004**
- RCS message with multiple people. **Working as of bec0a004**
- MMS thread with lots of people going back and forth. **working as of bec0a004**
- Message with 1 person, both SMS and MMS (texting a non-RCS user, but sometimes sending images). 
  - Less than 100 messages. **working as of bec0a004**
  - At least 100 sms messages before the MMS got backed up. **Not working, but you won't see it break as long as you backup frequently**
    - Unfortunately we'll probably have to live with this limitation. In theory it could be fixed, but it would require processing SMS and MMS messages interleaved, from oldest to newest. Those are pulled from two separate data sources and two queries, see `BackupItemsFetcher.getItemsForDataType` and `Consts.MMS_PROVIDER` / `SMS_PROVIDER`. So we would have to build some intermediate caching mechanism that gathers all the SMSs, gathers all the MMSs, interleaves them, then feeds them into the existing logic.
    - I tried using the "only backup 100 at a time" setting. Unfortunately it looks like this processes batches of SMSs first, then starts processing MMSs once the SMSs are exhausted. So it doesn't help.


## Adopting this new version

Here is my 2 cents for how affected users could get their backups into a clean-ish state:
- The "I don't care" way: just start using the new version, and everything going forwards will be fixed.
- The lazy way: just reset the backup state (or reinstall the app), back up everything again, and deal with duplicates in gmail.
- The harder way: Go into Gmail and update all existing emails with label `old-backups`. Download the new app version. Reset the backup state (or reinstall the app) and backup everything again (to your favorite label, like `SMS`). For whatever time period you still have on your phone, delete emails from that time period with label `old-backups`. Verify that you have a nice continuity when looking at both `old-backups` and `SMS`. Then change all the `old-backups` emails over to the `SMS` label.